### PR TITLE
Modify histogram relative position bar logic to fix race condition and improve speed

### DIFF
--- a/app.py
+++ b/app.py
@@ -521,8 +521,7 @@ def update_heatmap_y_axis_fig(_, data):
     :rtype: (plotly.graph_objects.Figure, dict)
     """
     y_axis_fig = heatmap_generator.get_heatmap_y_axis_fig(data)
-    y_axis_style = \
-        {"height": heatmap_generator.get_heatmap_cells_fig_height(data)}
+    y_axis_style = {"height": data["heatmap_cells_fig_height"]}
     return y_axis_fig, y_axis_style
 
 
@@ -547,8 +546,7 @@ def update_heatmap_gene_bar_fig(_, data):
     :rtype: (plotly.graph_objects.Figure, dict)
     """
     gene_bar_fig = heatmap_generator.get_heatmap_gene_bar_fig(data)
-    gene_bar_style = \
-        {"width": heatmap_generator.get_heatmap_cells_fig_width(data)}
+    gene_bar_style = {"width": data["heatmap_cells_fig_width"]}
     return gene_bar_fig, gene_bar_style
 
 
@@ -573,8 +571,7 @@ def update_heatmap_nt_pos_axis_fig(_, data):
     :rtype: (plotly.graph_objects.Figure, dict)
     """
     nt_pos_x_axis_fig = heatmap_generator.get_heatmap_nt_pos_axis_fig(data)
-    nt_pos_x_axis_style = \
-        {"width": heatmap_generator.get_heatmap_cells_fig_width(data)}
+    nt_pos_x_axis_style = {"width": data["heatmap_cells_fig_width"]}
     return nt_pos_x_axis_fig, nt_pos_x_axis_style
 
 
@@ -599,8 +596,7 @@ def update_heatmap_aa_pos_axis_fig(_, data):
     :rtype: (plotly.graph_objects.Figure, dict)
     """
     aa_pos_x_axis_fig = heatmap_generator.get_heatmap_aa_pos_axis_fig(data)
-    aa_pos_x_axis_style = \
-        {"width": heatmap_generator.get_heatmap_cells_fig_width(data)}
+    aa_pos_x_axis_style = {"width": data["heatmap_cells_fig_width"]}
     return aa_pos_x_axis_fig, aa_pos_x_axis_style
 
 
@@ -643,8 +639,8 @@ def update_heatmap_cells_fig(data):
     """
     cells_fig = heatmap_generator.get_heatmap_cells_fig(data)
     cells_fig_style = {
-        "height": heatmap_generator.get_heatmap_cells_fig_height(data),
-        "width": heatmap_generator.get_heatmap_cells_fig_width(data)
+        "height": data["heatmap_cells_fig_height"],
+        "width": data["heatmap_cells_fig_width"]
     }
     return cells_fig, cells_fig_style
 
@@ -800,9 +796,8 @@ app.clientside_callback(
         function_name="makeHistogramRelPosBarDynamic"
     ),
     Output("make-histogram-rel-pos-bar-dynamic", "data"),
-    Input("histogram", "id"),
-    Input("heatmap-cells-fig", "figure"),
-    Input("data", "data"),
+    Input("heatmap-nt-pos-axis-fig", "figure"),
+    State("data", "data")
 )
 
 if __name__ == "__main__":

--- a/assets/script.js
+++ b/assets/script.js
@@ -79,53 +79,57 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
      * the `histogram-rel-pos-bar` div.
      * This is quite hackey, because Plotly does not offer any native features
      * to implement this feature. This function returns nothing, but attaches a
-     * jQuery handler to keep watch as the user scrolls through the heatmap.
-     * Several allowances had to be made, so you should read the comments in
-     * the function below for further clarification, if needed.
-     * Our inputs provide no relevant information, but we chose to use the data
-     * dcc variable as an input because that is when the ticks in the heatmap
-     * may change, and the jQuery handler needs to be replaced. The input
-     * telling you the histogram and heatmap figures were rendered may prevent
-     * race conditions, since we are venturing outside Plotly and Dash here.
-     * @param _ Histogram figure rendered
-     * @param __ Heatmap center figure rendered
-     * @param ___ Data dcc variable changed
+     * jQuery handler to keep watch as the user scrolls through the heatmap. A
+     * new handler is attached everytime the heatmap nt pos axis figure is
+     * generated.
+     * Special precautions had to be taken due to the fact the heatmap nt pos
+     * axis figure may be generated before it is inserted into the dom, so we
+     * cannot rely on just parsing HTML from it on app launch.
+     * @param _ Heatmap nt pos axis figure generated
+     * @param {Object} data ``data_parser.get_data`` return value
      */
-    makeHistogramRelPosBarDynamic: (_, __, ___) => {
-      // A list of all ticks in the heatmap, and a sneaky calculation that tells
-      // you what the last histogram bin is going to be. Plotly does not give up
-      // that information easily.
-      const allTicks = $('#heatmap-nt-pos-axis-fig').find('.xtick>text')
-      const lastHistogramBin =
-          Math.ceil(parseInt(allTicks[allTicks.length-1].textContent)/100) * 100
-
+    makeHistogramRelPosBarDynamic: (_, data) => {
       const $heatmapCenterDiv = $('#heatmap-center-div')
+      const tickValArr = data['heatmap_x_nt_pos']
+      const heatmapCellsWidth = data['heatmap_cells_fig_width']
+      const tickWidth = heatmapCellsWidth / tickValArr.length
+      const lastHistogramBin =
+          Math.ceil(parseInt(tickValArr[tickValArr.length-1]/100) * 100)
+
       // We do not want to accumulate handlers
       $heatmapCenterDiv.off('scroll.foo')
       // Add the handler that dynamically changes the `histogram-rel-pos-bar`
       // div as the user scrolls.
       $heatmapCenterDiv.on('scroll.foo', (e) => {
         // Bounds of visible heatmap, which does not include overflow
-        const heatmapDivBounds = e.currentTarget.getBoundingClientRect()
-        // Filter ticks that are not hidden by overflow
-        const visibleTicks = allTicks.filter((_, el) => {
-          const tickDivBounds = el.getBoundingClientRect()
-          const tickDivCenter = tickDivBounds.left + tickDivBounds.width/2
-          const tooFarLeft = tickDivCenter < heatmapDivBounds.left
-          const tooFarRight = tickDivCenter > heatmapDivBounds.right
-          return !(tooFarLeft || tooFarRight)
-        })
-        // The ticks are text elements, so we need to retrieve their content
-        const leftBoundary =
-            parseInt(visibleTicks[0].textContent)
-        const rightBoundary =
-            parseInt(visibleTicks[visibleTicks.length-1].textContent)
+        const boundHeatmapWidth = e.currentTarget.getBoundingClientRect().width
+
+        const numOfVisibleTicks = Math.floor((boundHeatmapWidth / tickWidth))
+
+        // How far left the user has scrolled the heatmap
+        let scrollLeft = $heatmapCenterDiv.scrollLeft()
+        // We want to make scrollLeft === 0 at the beginning of the heatmap--
+        // not the beginning of the left padding.
+        scrollLeft -= parseInt($heatmapCenterDiv.css('padding-left'), 10)
+
+        // Index of first visible tick in ``tickValArr``
+        let leftMostVisibleTickIndex = Math.round(scrollLeft / tickWidth)
+        // Due to left padding, could be below 0. Make 0 if so.
+        leftMostVisibleTickIndex =
+            leftMostVisibleTickIndex < 0 ? 0 : leftMostVisibleTickIndex
+        // Index of last visible tick in ``tickValArr``
+        const rightMostVisibleTickIndex =
+            leftMostVisibleTickIndex + numOfVisibleTicks - 1
+
+        const leftMostVisibleTick = tickValArr[leftMostVisibleTickIndex]
+        const rightMostVisibleTick = tickValArr[rightMostVisibleTickIndex]
+
         // Calculate margins for `histogram-rel-pos-bar` as percents, and apply
         // them.
         const leftMarginPercent =
-            leftBoundary/lastHistogramBin * 100
+            leftMostVisibleTick/lastHistogramBin * 100
         const rightMarginPercent =
-            (lastHistogramBin-rightBoundary)/lastHistogramBin * 100
+            (lastHistogramBin-rightMostVisibleTick)/lastHistogramBin * 100
         const margins = {
           'margin-left': `${leftMarginPercent}%`,
           'margin-right': `${rightMarginPercent}%`

--- a/data_parser.py
+++ b/data_parser.py
@@ -354,6 +354,8 @@ def get_data(dirs, clade_defining=False, hidden_strains=None,
         get_heatmap_x_genes(heatmap_x_nt_pos)
     ret["heatmap_x_aa_pos"] = \
         get_heatmap_x_aa_pos(heatmap_x_nt_pos, ret["heatmap_x_genes"])
+    ret["heatmap_cells_fig_height"] = len(heatmap_y) * 40
+    ret["heatmap_cells_fig_width"] = len(heatmap_x_nt_pos) * 36
 
     return ret
 

--- a/generators/heatmap_generator.py
+++ b/generators/heatmap_generator.py
@@ -14,35 +14,6 @@ import plotly.graph_objects as go
 
 from definitions import GENE_COLORS_DICT
 
-def get_heatmap_cells_fig_height(data):
-    """Get the height in pixels for the heatmap cells fig.
-
-    Good to put this in a function because several other figs have to
-    be the same height.
-
-    :param data: ``data_parser.get_data`` return value
-    :type data: dict
-    :return: Heatmap cells fig height in pixels
-    :rtype: int
-    """
-    ret = len(data["heatmap_y"]) * 40
-    return ret
-
-
-def get_heatmap_cells_fig_width(data):
-    """Get the width in pixels for the heatmap cells fig.
-
-    Good to put this in a function because several other figs have to
-    be the same width.
-
-    :param data: ``data_parser.get_data`` return value
-    :type data: dict
-    :return: Heatmap cells fig height in pixels
-    :rtype: int
-    """
-    ret = len(data["heatmap_x_nt_pos"]) * 36
-    return ret
-
 
 def get_color_scale():
     """Get custom Plotly color scale.
@@ -73,8 +44,8 @@ def get_heatmap_row(data):
         and cols for heatmap view.
     :rtype: dbc.Row
     """
-    heatmap_cells_fig_height = get_heatmap_cells_fig_height(data)
-    heatmap_cells_fig_width = get_heatmap_cells_fig_width(data)
+    heatmap_cells_fig_height = data["heatmap_cells_fig_height"]
+    heatmap_cells_fig_width = data["heatmap_cells_fig_width"]
     ret = dbc.Row(
         [
             dbc.Col(


### PR DESCRIPTION
The clientside callback responsible for the histogram relative position bar logic could be triggered after the heatmap figures were generated, but before they were inserted into the DOM. As this callback relied on parsing the DOM to obtain heatmap nt pos axis tick values, this sometimes led to errors.

I have fixed this by modifying the callback logic to generate the histogram relative position bar margins without parsing the DOM. I have also inadvertently improved the performance of this callback by doing so, as the function previously called by the jQuery handler was O(n), but it is now O(1). 