### PR TITLE
Added python's os path join fn in a few places it was missing

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ run faster.
 """
 
 from base64 import b64decode
+from os import path
 from time import sleep
 
 import dash
@@ -26,7 +27,7 @@ from dash.dependencies import ALL, ClientsideFunction, Input, Output, State
 from dash.exceptions import PreventUpdate
 
 from data_parser import get_data, vcf_str_to_gvf_str
-from definitions import REFERENCE_DATA_DIR, USER_DATA_DIR
+from definitions import ASSETS_DIR, REFERENCE_DATA_DIR, USER_DATA_DIR
 from generators import (heatmap_generator, histogram_generator,
                         table_generator, toolbar_generator)
 
@@ -35,9 +36,8 @@ from generators import (heatmap_generator, histogram_generator,
 # contains the visualization that is deployed by this file, when
 # ``app`` is served.
 app = dash.Dash(
-    # Fixes bug with debugger in PyCharm. See
-    # https://bit.ly/3j86GL1.
-    name="foo",
+    name="COVID-MVP",
+    assets_folder=ASSETS_DIR,
     # We bring in jQuery for some of the JavaScript
     # callbacks.
     external_scripts=[
@@ -258,7 +258,7 @@ def update_new_upload(file_contents, filename, old_data):
         vcf_str_bytes = b64decode(base64_str)
         vcf_str_utf8 = vcf_str_bytes.decode("utf-8")
         gvf_str = vcf_str_to_gvf_str(vcf_str_utf8, new_strain)
-        with open("user_data/" + new_strain + ".gvf", "w") as fp:
+        with open(path.join(USER_DATA_DIR, new_strain + ".gvf"), "w") as fp:
             fp.write("\n\n\n" + gvf_str)
         status = "ok"
         msg = ""

--- a/definitions.py
+++ b/definitions.py
@@ -4,8 +4,9 @@ import os
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 REFERENCE_DATA_DIR = os.path.join(ROOT_DIR, "reference_data")
 USER_DATA_DIR = os.path.join(ROOT_DIR, "user_data")
-GENE_COLORS_PATH = os.path.join(ROOT_DIR, "assets/gene_colors.json")
-GENE_POSITIONS_PATH = os.path.join(ROOT_DIR, "assets/gene_positions.json")
+ASSETS_DIR = os.path.join(ROOT_DIR, "assets")
+GENE_COLORS_PATH = os.path.join(ROOT_DIR, "assets", "gene_colors.json")
+GENE_POSITIONS_PATH = os.path.join(ROOT_DIR, "assets", "gene_positions.json")
 
 with open(GENE_COLORS_PATH) as fp:
     GENE_COLORS_DICT = json.load(fp)


### PR DESCRIPTION
It was missing in the upload fn code, which gave issues sometimes on windows 10.

Also introduced to reference the assets dir as a global variable, which integrates nicer with pyinstaller if we go down that route.

Also renamed the dash app from foo to covid-mvp.