### PR TITLE
Surface level vocabulary generalization

### DIFF
--- a/generators/heatmap_generator.py
+++ b/generators/heatmap_generator.py
@@ -55,7 +55,7 @@ def get_heatmap_row(data):
                     # Space for voc and voi legend
                     dbc.Row(
                         dbc.Col(
-                            "Variants",
+                            "Sample groups",
                             className="text-right h5",
                             style={"padding-top": 105, "padding-right": 15}
                         ),

--- a/generators/legend_generator.py
+++ b/generators/legend_generator.py
@@ -108,7 +108,7 @@ def get_axes_description():
                 html.B("bold"),
                 ", and VOI are in ",
                 html.I("italics"),
-                ". Actively circulating strains are denoted with ⚠️."
+                ". Actively circulating lineages are denoted with ⚠️."
             ]),
             dbc.Col([
                 html.B("Top axis: "),

--- a/generators/toolbar_generator.py
+++ b/generators/toolbar_generator.py
@@ -82,7 +82,7 @@ def get_select_lineages_toolbar_btn():
         for selecting lineages.
     :rtype: dbc.Button
     """
-    return dbc.Button("Select lineages",
+    return dbc.Button("Select groups",
                       id="open-select-lineages-modal-btn",
                       className="mr-2")
 
@@ -97,7 +97,7 @@ def get_select_lineages_modal():
     :rtype: dbc.Modal
     """
     return dbc.Modal([
-        dbc.ModalHeader("Select lineages"),
+        dbc.ModalHeader("Select sample groups"),
         # Empty at launch; populated when user opens modal
         dbc.ModalBody(None,
                       id="select-lineages-modal-body",


### PR DESCRIPTION
Partially addresses #188 

A lot of code base references to lineages, strains, etc. remain

But this removes the reference users see in the interface